### PR TITLE
Update openasu.info

### DIFF
--- a/profiles/openasu/openasu.info
+++ b/profiles/openasu/openasu.info
@@ -20,6 +20,7 @@ dependencies[] = field_ui
 dependencies[] = file
 dependencies[] = dblog
 dependencies[] = update
+dependencies[] = contextual
 
 ; Panopoly Foundation
 dependencies[] = panopoly_core


### PR DESCRIPTION
Update openasu.info to enable contextual links by default
