### PR TITLE
137-enable-contextual-links-module-by-default

### DIFF
--- a/profiles/openasu/openasu.info
+++ b/profiles/openasu/openasu.info
@@ -20,6 +20,7 @@ dependencies[] = field_ui
 dependencies[] = file
 dependencies[] = dblog
 dependencies[] = update
+dependencies[] = contextual
 
 ; Panopoly Foundation
 dependencies[] = panopoly_core


### PR DESCRIPTION
Enable contextual links module on install by default. Fixes JIRA WEBSPARK-137
