### PR TITLE
Fix invalid HTML attribute usage on H1 element

### DIFF
--- a/profiles/openasu/themes/innovation/templates/page.tpl.php
+++ b/profiles/openasu/themes/innovation/templates/page.tpl.php
@@ -87,7 +87,7 @@
 					<?php print render($page['header']); ?>
 
 					<?php if ($site_name): ?>
-							<h1 class="header__sitename<?php if ($hide_site_name) { print ' element-invisible'; } ?>">
+							<h1 class="header__sitename<?php if ($hide_site_name) { print ' hidden'; } ?>">
 									<a href="<?php print $front_page; ?>" title="<?php print t('Home'); ?>" rel="home"><span><?php print $site_name; ?></span></a>
 							</h1>
 					<?php endif; ?>

--- a/profiles/openasu/themes/innovation/templates/page.tpl.php
+++ b/profiles/openasu/themes/innovation/templates/page.tpl.php
@@ -87,7 +87,7 @@
 					<?php print render($page['header']); ?>
 
 					<?php if ($site_name): ?>
-							<h1 class="header__sitename"<?php if ($hide_site_name) { print ' class="element-invisible"'; } ?>>
+							<h1 class="header__sitename<?php if ($hide_site_name) { print ' element-invisible'; } ?>">
 									<a href="<?php print $front_page; ?>" title="<?php print t('Home'); ?>" rel="home"><span><?php print $site_name; ?></span></a>
 							</h1>
 					<?php endif; ?>


### PR DESCRIPTION
When $hide_site_name evaluates to true, the &lt;h1&gt; tag gets duplicate class attributes, causing the second attribute to be ignored by user agents.

As a result, the Bootstrap CSS styling hook becomes ineffective and the site name does not get hidden based on the appearance theme setting.