### PR TITLE
Fix misspelled word, "visbility", in theme appearance

### DIFF
--- a/profiles/openasu/themes/kalatheme/styles/kalacustomize/kalacustomize.inc
+++ b/profiles/openasu/themes/kalatheme/styles/kalacustomize/kalacustomize.inc
@@ -7,7 +7,7 @@
 
 $plugin = array(
   'title' => t('Kalacustomize'),
-  'description' => t('Customize elements, visbility and classes with Twitter Bootstrap'),
+  'description' => t('Customize elements, visibility and classes with Twitter Bootstrap'),
   'render region' => 'kalatheme_kalacustomize_render_region',
   'render pane' => 'kalatheme_kalacustomize_render_pane',
   'settings form' => 'kalatheme_kalacustomize_pane_settings_form',

--- a/profiles/openasu/themes/kalatheme/theme-settings.php
+++ b/profiles/openasu/themes/kalatheme/theme-settings.php
@@ -69,7 +69,7 @@ function kalatheme_form_system_theme_settings_alter(&$form, &$form_state) {
     '#type' => 'checkbox',
     '#title' => t('Use responsive toggling.'),
     '#default_value' => theme_get_setting('responsive_toggle'),
-    '#description' => t('Check here if you want the user to be able to set the device visbility of each panels pane and region.'),
+    '#description' => t('Check here if you want the user to be able to set the device visibility of each panels pane and region.'),
   );
 
   // Panels styles style plugin settings.


### PR DESCRIPTION
When using a [Webspark subtheme][1], there's a misspelling in the Kalatheme's appearance settings:

![](https://cloud.githubusercontent.com/assets/133372/9238779/db564d0e-4109-11e5-9634-9e6a00e19ed4.png)

This pull requests fixes the misspelled word, "visbility".

[1]: https://webspark.asu.edu/tools/customizing