### PR TITLE
Fix PHP notice in Webspark Kalatheme theme function for rendering a region

### DIFF
--- a/profiles/openasu/themes/kalatheme/styles/kalacustomize/kalacustomize.inc
+++ b/profiles/openasu/themes/kalatheme/styles/kalacustomize/kalacustomize.inc
@@ -23,8 +23,8 @@ function theme_kalatheme_kalacustomize_render_region($vars) {
   $settings = $vars['settings'];
 
   $settings['attributes'] = '';
-  $settings['attributes'] .= _kalatheme_get_styles($settings['devices']);
-  $settings['attributes'] .= _kalatheme_get_styles($settings['pane_style']);
+  $settings['attributes'] .= _kalatheme_get_styles(isset($settings['devices']) ? $settings['devices'] : NULL);
+  $settings['attributes'] .= _kalatheme_get_styles(isset($settings['pane_style']) ? $settings['pane_style'] : NULL);
 
     // Theme.
   if (!empty($settings['theme']) && $settings['theme']) {


### PR DESCRIPTION
These notices occur when the function `_kalatheme_get_styles()` is passed an array with undefined indexes, for example:

```
_kalatheme_get_styles($settings['devices']);
_kalatheme_get_styles($settings['pane_style']);
```

The PHP notices printed to the screen in Drupal show:

```
Notice: Undefined index: devices in theme_kalatheme_kalacustomize_render_region()
(line 26 of /profiles/openasu/themes/kalatheme/styles/kalacustomize/kalacustomize.inc).

Notice: Undefined index: pane_style in theme_kalatheme_kalacustomize_render_region()
(line 27 of /profiles/openasu/themes/kalatheme/styles/kalacustomize/kalacustomize.inc).
```

This pull request fixes the notices by checking whether the array index is set.

The behavior is present in the latest release, Webspark v1.13.13 (Hanford) as of December 2015.