### PR TITLE
Adding rule for sizing of home icon as per web standards. 

### DIFF
--- a/profiles/openasu/modules/webspark_featurescustom/webspark_megamenu/css/webspark_megamenu.css
+++ b/profiles/openasu/modules/webspark_featurescustom/webspark_megamenu/css/webspark_megamenu.css
@@ -34,6 +34,7 @@ li.tb-megamenu-item.mega a {
 .tb-megamenu i.fa.fa-home.icon-white {
     margin-right: 0;
     display: block !important;
+    font-size: 16px;
 }
 
 .tb-megamenu .nav li.dropdown.open > .dropdown-toggle, .tb-megamenu .nav > li > a:focus, .tb-megamenu .nav > .active > a:focus, .tb-megamenu .nav li.dropdown.open.active > .dropdown-toggle, .tb-megamenu .nav > li.dropdown.open.active > a:hover, .tb-megamenu .nav > li > a:hover {


### PR DESCRIPTION
On ISEARCH-408, David Davis brought to my attention that the home icon should be 16px per web standards.  I've addressed this issue there, but thought you might want to merge this update into Webspark.

References:
- https://brandguide.asu.edu/web-standards/enterprise/iconography
- https://asudev.jira.com/browse/ISEARCH-408