### PR TITLE
WEBSPARK-834 - Prevent the RFI from hiding non-rfi forms from users

### DIFF
--- a/profiles/openasu/modules/custom/asu_rfi/asu_rfi.module
+++ b/profiles/openasu/modules/custom/asu_rfi/asu_rfi.module
@@ -28,15 +28,12 @@ DRUPAL HOOKS
  * Implements hook_permission().
  */
 function asu_rfi_permission() {
-  // TODO not used anywhere yet...
-  $perms = array(
-    'asu access lead export tool' => array(
-      'title' => t('Administer ASU RFI module'),
-      'description' => t('Administer ASU RFI module'),
-    ),
-  );
-
-  return $perms;
+    return array(
+        'administer asu rfi' => array(
+            'title' => t('Administer ASU RFI'),
+            'description' => t('Administer ASU RFI module'),
+        ),
+    );
 }
 
 /**
@@ -75,7 +72,7 @@ function asu_rfi_menu() {
     'description' => t('Administer RFI form settings.'),
     'page callback' => 'drupal_get_form',
     'page arguments' => array('asu_rfi_admin_settings'),
-    'access arguments' => array('access administration pages'),
+    'access arguments' => array('administer asu rfi'),
     'options' => array('attributes' => array('class' => 'title')),
     'type' => MENU_NORMAL_ITEM,
     'file' => 'includes/asu_rfi.admin.inc'
@@ -793,17 +790,17 @@ function asu_rfi_form_alter(&$form, &$form_state, $form_id){
    //Get the RFI form mode settings, if form is in test mode, give only admins access to the form view
    $rfi_mode = variable_get('asu_rfi_form_mode');
     global $user;
-    
-      if(($rfi_mode == "test") || empty($rfi_mode)){
-         if(user_access('administer nodes', $user) == 1){
+
+    if((($rfi_mode == "test") || empty($rfi_mode)) && ($form['#id'] == "asu-rfi-form-data" || $form['#id'] == "asu-rfi-long-form-data" || $form['#id'] == 'views-exposed-form-asu-rfi-submissions-report-page')){
+        if(user_access('administer nodes', $user) == 1 || user_access('administer asu rfi', $user) == 1){
             return true;
-         }
-        else{
-           $form['#access'] = FALSE;
-           drupal_set_message("You do not have access to view this form",'warning');
-           return false;
         }
-      }
+        else{
+            $form['#access'] = FALSE;
+            drupal_set_message("You do not have access to view this form",'warning');
+            return false;
+        }
+    }
      
 }
 


### PR DESCRIPTION
Fixed this issue by configuring the RFI module's permissions.