### PR TITLE
fixed mega_footer save action for valid URL

### DIFF
--- a/profiles/openasu/modules/webspark_featurescustom/mega_footer/mega_footer.module
+++ b/profiles/openasu/modules/webspark_featurescustom/mega_footer/mega_footer.module
@@ -439,10 +439,10 @@ function mega_footer_block_validate(&$form, $form_state) {
   $delta = $form['delta']['#value'];
   if ($delta == 'mega_footer') {
     foreach ($form_state['values'] as $haystack => $straw) {
-      if (!is_array($straw)) {
+      if (!is_array($straw) && !empty($straw)) {
         if (stristr($haystack, '_link')) {
           $absolute = TRUE;
-          if ($straw == 'mega_footer_unit_contact_us_link' || $straw == 'mega_footer_contribute_link' || $straw == 'mega_footer_unit_rss_link') {
+          if ($haystack == 'mega_footer_unit_contact_us_link' || $haystack == 'mega_footer_contribute_link' || $haystack == 'mega_footer_unit_rss_link') {
             $absolute = FALSE;
           }
           if (!valid_url($straw, $absolute)) {


### PR DESCRIPTION
Steps to recreate:
1. update to latest webspark update
2. Navigate to admin/structure/block/manage/mega_footer/mega_footer/configure
3. Enter valid relative URL for "contact Us" field and an absolute URL for "facebook" field.
4. Click "save block"
5. Observer the error on the top of the page.

On saving, I got a validation error stating I need to enter URL for every field on the page except the facebook field.
<img width="995" alt="screen shot 2018-05-29 at 11 28 07 am" src="https://user-images.githubusercontent.com/14724465/40691914-7a68b8c2-6363-11e8-841b-508ba944fa0a.png">
