### PR TITLE
Mega Menu Home Icon Fix

### DIFF
--- a/profiles/openasu/themes/innovation/css/buttons.css
+++ b/profiles/openasu/themes/innovation/css/buttons.css
@@ -92,7 +92,7 @@
     color: white;
 }
 .btn-blue:hover, .btn-blue:focus, .btn-blue:active, .btn-blue.active, .open > .btn-blue.dropdown-toggle {
-    background-color: #0aa9fc;
+    background-color: #0085E2;
     color: white;
 }
 .btn-blue:active, .btn-blue.active, .open > .btn-blue.dropdown-toggle {


### PR DESCRIPTION
Fix for home icon (in mega menu) was bumped out by a previous merge. Changes icon from <i> to <span> for accessibility.